### PR TITLE
Properly destroy chartjs objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vue-ChartJs
 
-[![npm version](https://badge.fury.io/js/vue-chartjs.svg)](https://badge.fury.io/js/vue-chartjs)
+[![npm version](https://badge.fury.io/js/vue-chartjs.svg)] (https://badge.fury.io/js/vue-chartjs) ![npm dependencies](https://david-dm.org/apertureless/vue-chartjs.svg) 
 
 > VueJS wrapper for ChartJs
 

--- a/src/BaseCharts/Bar.js
+++ b/src/BaseCharts/Bar.js
@@ -45,14 +45,17 @@ export default Vue.extend({
 
   methods: {
     render (data, options = this.options) {
-      const chart = new Chart(
+      this._chart = new Chart(
         this.$els.canvas.getContext('2d'), {
           type: 'bar',
           data: data,
           options: options
         }
       )
-      chart.generateLegend()
+      this._chart.generateLegend()
     }
+  },
+  destroy () {
+    this._chart.destroy()
   }
 })

--- a/src/BaseCharts/Bar.js
+++ b/src/BaseCharts/Bar.js
@@ -55,7 +55,7 @@ export default Vue.extend({
       this._chart.generateLegend()
     }
   },
-  destroy () {
+  beforeDestroy () {
     this._chart.destroy()
   }
 })

--- a/src/BaseCharts/Doughnut.js
+++ b/src/BaseCharts/Doughnut.js
@@ -28,14 +28,17 @@ export default Vue.extend({
 
   methods: {
     render (data, options = this.options) {
-      const chart = new Chart(
+      this._chart = new Chart(
         this.$els.canvas.getContext('2d'), {
           type: 'doughnut',
           data: data,
           options: options
         }
       )
-      chart.generateLegend()
+      this._chart.generateLegend()
     }
+  },
+  destroy () {
+    this._chart.destroy()
   }
 })

--- a/src/BaseCharts/Doughnut.js
+++ b/src/BaseCharts/Doughnut.js
@@ -38,7 +38,7 @@ export default Vue.extend({
       this._chart.generateLegend()
     }
   },
-  destroy () {
+  beforeDestroy () {
     this._chart.destroy()
   }
 })

--- a/src/BaseCharts/Line.js
+++ b/src/BaseCharts/Line.js
@@ -53,7 +53,7 @@ export default Vue.extend({
       this._chart.generateLegend()
     }
   },
-  destroy () {
+  beforeDestroy () {
     this._chart.destroy()
   }
 })

--- a/src/BaseCharts/Line.js
+++ b/src/BaseCharts/Line.js
@@ -43,14 +43,17 @@ export default Vue.extend({
 
   methods: {
     render (data, options = this.options) {
-      const chart = new Chart(
+      this._chart = new Chart(
         this.$els.canvas.getContext('2d'), {
           type: 'line',
           data: data,
           options: options
         }
       )
-      chart.generateLegend()
+      this._chart.generateLegend()
     }
+  },
+  destroy () {
+    this._chart.destroy()
   }
 })

--- a/src/BaseCharts/Pie.js
+++ b/src/BaseCharts/Pie.js
@@ -28,14 +28,17 @@ export default Vue.extend({
 
   methods: {
     render (data, options = this.options) {
-      const chart = new Chart(
+      this._chart = new Chart(
         this.$els.canvas.getContext('2d'), {
           type: 'pie',
           data: data,
           options: options
         }
       )
-      chart.generateLegend()
+      this._chart.generateLegend()
     }
+  },
+  destroy () {
+    this._chart.destroy()
   }
 })

--- a/src/BaseCharts/Pie.js
+++ b/src/BaseCharts/Pie.js
@@ -38,7 +38,7 @@ export default Vue.extend({
       this._chart.generateLegend()
     }
   },
-  destroy () {
+  beforeDestroy () {
     this._chart.destroy()
   }
 })

--- a/src/BaseCharts/PolarArea.js
+++ b/src/BaseCharts/PolarArea.js
@@ -28,14 +28,17 @@ export default Vue.extend({
 
   methods: {
     render (data, options = this.options) {
-      const chart = new Chart(
+      this._chart = new Chart(
         this.$els.canvas.getContext('2d'), {
           type: 'polarArea',
           data: data,
           options: options
         }
       )
-      chart.generateLegend()
+      this._chart.generateLegend()
     }
+  },
+  destroy () {
+    this._chart.destroy()
   }
 })

--- a/src/BaseCharts/PolarArea.js
+++ b/src/BaseCharts/PolarArea.js
@@ -38,7 +38,7 @@ export default Vue.extend({
       this._chart.generateLegend()
     }
   },
-  destroy () {
+  beforeDestroy () {
     this._chart.destroy()
   }
 })

--- a/src/BaseCharts/Radar.js
+++ b/src/BaseCharts/Radar.js
@@ -28,14 +28,17 @@ export default Vue.extend({
 
   methods: {
     render (data, options = this.options) {
-      const chart = new Chart(
+      this._chart = new Chart(
         this.$els.canvas.getContext('2d'), {
           type: 'radar',
           data: data,
           options: options
         }
       )
-      chart.generateLegend()
+      this._chart.generateLegend()
     }
+  },
+  destroy () {
+    this._chart.destroy()
   }
 })

--- a/src/BaseCharts/Radar.js
+++ b/src/BaseCharts/Radar.js
@@ -38,7 +38,7 @@ export default Vue.extend({
       this._chart.generateLegend()
     }
   },
-  destroy () {
+  beforeDestroy () {
     this._chart.destroy()
   }
 })


### PR DESCRIPTION
Currently, the chartjs object is not properly destroyed (cleaning up event listeners etc) when the component is destroyed.

This pull request saves the chart instance on the component and adds a `destroy()` hook to the component that calls the chart instance's `.destroy()` method to ensure proper cleanup.
```js
methods: {
    render (data, options = this.options) {
      this._chart = new Chart( // save instance on a property of the vm
        this.$els.canvas.getContext('2d'), {
          type: 'bar',
          data: data,
          options: options
        }
      )
      this._chart.generateLegend()
    }
  },
  beforeDestroy () {
    this._chart.destroy() //destroy chart when component is destroyed
  }
```