### PR TITLE
Added browserify support

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,10 @@
     "webpack-dev-middleware": "^1.4.0",
     "webpack-hot-middleware": "^2.6.0",
     "webpack-merge": "^1.1.1"
+  },
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
   }
 }


### PR DESCRIPTION
Added the `babilify` transform for `browserify` in `packge.json` so the `src` files can be transpiled in browserify projects.

### Fix or Enhancement?

Browserify applies transforms on a per-module basis and doesn't appear to allow global transforms, meaning that `babelify` needs to be declared in the modules `package.json` in order to transpile the `ES2015` code in `src`.

In order for a browserify user to transpile the code, they would need to install [babelify](https://www.npmjs.com/package/babelify) and [babel-preset-es2015](https://www.npmjs.com/package/babel-preset-es2015) and add a `.babelrc` file in the root of their project with the following code:

```
{ 
"presets": ["es2015"]
}
```
I think you could get away with explaining that rather than creating a dependency for `babelify` and `babel-preset-es2015` because many `vue/browserify` users will already have their projects set up this way.