### PR TITLE
Update release build to not include externals.

### DIFF
--- a/build/webpack.release.js
+++ b/build/webpack.release.js
@@ -15,6 +15,11 @@ module.exports = {
     libraryTarget: 'umd',
     umdNamedDefine: true
   },
+  externals: {
+    'vue': 'vue',
+    'lodash': 'lodash',
+    'chart.js': 'chart.js'
+  },
   module: {
     preLoaders: [
       {

--- a/build/webpack.release.js
+++ b/build/webpack.release.js
@@ -17,7 +17,6 @@ module.exports = {
   },
   externals: {
     'vue': 'vue',
-    'lodash': 'lodash',
     'chart.js': 'chart.js'
   },
   module: {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "release": "webpack --progress --hide-modules --config  ./build/webpack.release.js && NODE_ENV=production webpack --progress --hide-modules --config  ./build/webpack.release.min.js",
     "prepublish": "yarn run lint && yarn run test && yarn run build"
   },
-  "dependencies": {
+  "peerDependencies": {
     "chart.js": "^2.5.0",
     "lodash": "^4.17.4",
     "vue": "^2.2.6"
@@ -70,6 +70,7 @@
     "babel-preset-stage-2": "^6.22.0",
     "babel-runtime": "^6.23.0",
     "chai": "^3.5.0",
+    "chart.js": "^2.5.0",
     "chromedriver": "^2.28.0",
     "connect-history-api-fallback": "^1.1.0",
     "cross-env": "^3.2.4",
@@ -102,6 +103,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.30",
     "karma-webpack": "1.8.1",
+    "lodash": "^4.17.4",
     "lolex": "^1.6.0",
     "mocha": "^3.1.0",
     "nightwatch": "^0.9.14",
@@ -112,6 +114,7 @@
     "sinon": "^2.1.0",
     "sinon-chai": "^2.9.0",
     "url-loader": "^0.5.8",
+    "vue": "^2.2.6",
     "vue-hot-reload-api": "^2.0.11",
     "vue-html-loader": "^1.2.4",
     "vue-loader": "^11.3.4",

--- a/package.json
+++ b/package.json
@@ -56,9 +56,11 @@
     "release": "webpack --progress --hide-modules --config  ./build/webpack.release.js && NODE_ENV=production webpack --progress --hide-modules --config  ./build/webpack.release.min.js",
     "prepublish": "yarn run lint && yarn run test && yarn run build"
   },
+  "dependencies": {
+    "lodash": "^4.17.4"
+  },
   "peerDependencies": {
     "chart.js": "^2.5.0",
-    "lodash": "^4.17.4",
     "vue": "^2.2.6"
   },
   "devDependencies": {
@@ -103,7 +105,6 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.30",
     "karma-webpack": "1.8.1",
-    "lodash": "^4.17.4",
     "lolex": "^1.6.0",
     "mocha": "^3.1.0",
     "nightwatch": "^0.9.14",


### PR DESCRIPTION
This PR is an enhancement proposal focusing on the removal of all external deps (vue, graph.js, ...) from the final build and will also reduce minified build size from 500 kB to 59.1 kB.
