### PR TITLE
Fix reactive mixins animation re-rendering issue.

### DIFF
--- a/src/mixins/reactiveData.js
+++ b/src/mixins/reactiveData.js
@@ -26,7 +26,26 @@ module.exports = {
           // Check if Labels are equal and if dataset length is equal
           if (newLabels === oldLabels && oldData.datasets.length === newData.datasets.length) {
             newData.datasets.forEach((dataset, i) => {
-              chart.data.datasets[i] = dataset
+              // Get new and old dataset keys
+              const oldDatasetKeys = Object.keys(oldData.datasets[i])
+              const newDatasetKeys = Object.keys(dataset)
+              
+              // Get keys that aren't present in the new data
+              const deletionKeys = oldDatasetKeys.filter((key) => {
+                return key !== '_meta' && newDatasetKeys.indexOf(key) === -1
+              })
+              
+              // Remove outdated key-value pairs
+              deletionKeys.forEach((deletionKey) => {
+                delete chart.data.datasets[i][deletionKey]
+              })
+              
+              // Update attributes individually to avoid re-rendering the entire chart
+              for (const attribute in dataset) {
+                if (dataset.hasOwnProperty(attribute)) {
+                  chart.data.datasets[i][attribute] = dataset[attribute]
+                }
+              }
             })
 
             chart.data.labels = newData.labels

--- a/src/mixins/reactiveData.js
+++ b/src/mixins/reactiveData.js
@@ -29,17 +29,17 @@ module.exports = {
               // Get new and old dataset keys
               const oldDatasetKeys = Object.keys(oldData.datasets[i])
               const newDatasetKeys = Object.keys(dataset)
-              
+
               // Get keys that aren't present in the new data
               const deletionKeys = oldDatasetKeys.filter((key) => {
                 return key !== '_meta' && newDatasetKeys.indexOf(key) === -1
               })
-              
+
               // Remove outdated key-value pairs
               deletionKeys.forEach((deletionKey) => {
                 delete chart.data.datasets[i][deletionKey]
               })
-              
+
               // Update attributes individually to avoid re-rendering the entire chart
               for (const attribute in dataset) {
                 if (dataset.hasOwnProperty(attribute)) {

--- a/src/mixins/reactiveProp.js
+++ b/src/mixins/reactiveProp.js
@@ -27,7 +27,26 @@ module.exports = {
           // Check if Labels are equal and if dataset length is equal
           if (newLabels === oldLabels && oldData.datasets.length === newData.datasets.length) {
             newData.datasets.forEach((dataset, i) => {
-              chart.data.datasets[i] = dataset
+              // Get new and old dataset keys
+              const oldDatasetKeys = Object.keys(oldData.datasets[i])
+              const newDatasetKeys = Object.keys(dataset)
+              
+              // Get keys that aren't present in the new data
+              const deletionKeys = oldDatasetKeys.filter((key) => {
+                return key !== '_meta' && newDatasetKeys.indexOf(key) === -1
+              })
+              
+              // Remove outdated key-value pairs
+              deletionKeys.forEach((deletionKey) => {
+                delete chart.data.datasets[i][deletionKey]
+              })
+              
+              // Update attributes individually to avoid re-rendering the entire chart
+              for (const attribute in dataset) {
+                if (dataset.hasOwnProperty(attribute)) {
+                  chart.data.datasets[i][attribute] = dataset[attribute]
+                }
+              }
             })
 
             chart.data.labels = newData.labels

--- a/src/mixins/reactiveProp.js
+++ b/src/mixins/reactiveProp.js
@@ -4,7 +4,6 @@ module.exports = {
       required: true
     }
   },
-
   watch: {
     'chartData': {
       handler (newData, oldData) {

--- a/src/mixins/reactiveProp.js
+++ b/src/mixins/reactiveProp.js
@@ -29,17 +29,17 @@ module.exports = {
               // Get new and old dataset keys
               const oldDatasetKeys = Object.keys(oldData.datasets[i])
               const newDatasetKeys = Object.keys(dataset)
-              
+
               // Get keys that aren't present in the new data
               const deletionKeys = oldDatasetKeys.filter((key) => {
                 return key !== '_meta' && newDatasetKeys.indexOf(key) === -1
               })
-              
+
               // Remove outdated key-value pairs
               deletionKeys.forEach((deletionKey) => {
                 delete chart.data.datasets[i][deletionKey]
               })
-              
+
               // Update attributes individually to avoid re-rendering the entire chart
               for (const attribute in dataset) {
                 if (dataset.hasOwnProperty(attribute)) {


### PR DESCRIPTION
A small consequence of replacing the entire dataset in the [reactive mixins files](https://github.com/apertureless/vue-chartjs/blob/develop/src/mixins/reactiveProp.js) is that it causes charts to completely re-render even if only the 'data' attribute of a dataset is changing. In my case, I set up a reactive doughnut chart with two data points but whenever the data values change, instead of shifting the fill coloring, it completely re-renders the entire chart.

You can see the issue in this fiddle (the problem remains even when changing chart type):
https://jsfiddle.net/sg0c82ev/11/

To solve the issue, I instead run a diff between the new and old dataset keys, remove keys that aren't present in the new data,  and update the rest of the attributes individually. After making these changes my doughnut chart is animating as expected (even when adding and removing new dataset attributes).

A fiddle with my changes:
https://jsfiddle.net/sg0c82ev/12/

Perhaps this is too specific of a scenario to warrant a complexity increase (and better suited for a custom handler) but I figured it would be better to dump it here and make it available for review. Let me know what you think.

### Environment
- OS: Mac OS 10.11.6
- NPM Version: 3.10.3