### PR TITLE
Fix beforeDestory when renderChart was not called

### DIFF
--- a/src/BaseCharts/Bar.js
+++ b/src/BaseCharts/Bar.js
@@ -79,6 +79,8 @@ export default Vue.extend({
     }
   },
   beforeDestroy () {
-    this._chart.destroy()
+    if (this._chart) {
+      this._chart.destroy()
+    }
   }
 })

--- a/src/BaseCharts/Bubble.js
+++ b/src/BaseCharts/Bubble.js
@@ -80,6 +80,8 @@ export default Vue.extend({
     }
   },
   beforeDestroy () {
-    this._chart.destroy()
+    if (this._chart) {
+      this._chart.destroy()
+    }
   }
 })

--- a/src/BaseCharts/Doughnut.js
+++ b/src/BaseCharts/Doughnut.js
@@ -63,6 +63,8 @@ export default Vue.extend({
     }
   },
   beforeDestroy () {
-    this._chart.destroy()
+    if (this._chart) {
+      this._chart.destroy()
+    }
   }
 })

--- a/src/BaseCharts/HorizontalBar.js
+++ b/src/BaseCharts/HorizontalBar.js
@@ -79,6 +79,8 @@ export default Vue.extend({
     }
   },
   beforeDestroy () {
-    this._chart.destroy()
+    if (this._chart) {
+      this._chart.destroy()
+    }
   }
 })

--- a/src/BaseCharts/Line.js
+++ b/src/BaseCharts/Line.js
@@ -78,6 +78,8 @@ export default Vue.extend({
     }
   },
   beforeDestroy () {
-    this._chart.destroy()
+    if (this._chart) {
+      this._chart.destroy()
+    }
   }
 })

--- a/src/BaseCharts/Pie.js
+++ b/src/BaseCharts/Pie.js
@@ -63,6 +63,8 @@ export default Vue.extend({
     }
   },
   beforeDestroy () {
-    this._chart.destroy()
+    if (this._chart) {
+      this._chart.destroy()
+    }
   }
 })

--- a/src/BaseCharts/PolarArea.js
+++ b/src/BaseCharts/PolarArea.js
@@ -63,6 +63,8 @@ export default Vue.extend({
     }
   },
   beforeDestroy () {
-    this._chart.destroy()
+    if (this._chart) {
+      this._chart.destroy()
+    }
   }
 })

--- a/src/BaseCharts/Radar.js
+++ b/src/BaseCharts/Radar.js
@@ -63,6 +63,8 @@ export default Vue.extend({
     }
   },
   beforeDestroy () {
-    this._chart.destroy()
+    if (this._chart) {
+      this._chart.destroy()
+    }
   }
 })

--- a/src/BaseCharts/Scatter.js
+++ b/src/BaseCharts/Scatter.js
@@ -64,6 +64,8 @@ export default Vue.extend({
     }
   },
   beforeDestroy () {
-    this._chart.destroy()
+    if (this._chart) {
+      this._chart.destroy()
+    }
   }
 })


### PR DESCRIPTION
### Fix

If `renderChart()` was somehow not called before the component was destroyed, the component will raise an exception because `this._chart` is undefined. This patch ensures that `this._chart.destroy()` will only be called if `this._chart` has actually been initialized. 

- [X] All tests passed
