### PR TITLE
Replace Object.assign with deepmerge

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": ["es2015", "stage-2"],
-  "plugins": ["transform-runtime", "transform-object-assign"],
+  "plugins": ["transform-runtime"],
   "comments": false
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "release": "webpack --progress --hide-modules --config  ./build/webpack.release.js && NODE_ENV=production webpack --progress --hide-modules --config  ./build/webpack.release.min.js && webpack --progress --hide-modules --config  ./build/webpack.release.full.js && NODE_ENV=production webpack --progress --hide-modules --config  ./build/webpack.release.full.min.js",
     "prepublish": "yarn run lint && yarn run test && yarn run build"
   },
-  "dependencies": {},
+  "dependencies": {
+    "deepmerge": "^1.5.1"
+  },
   "peerDependencies": {
     "chart.js": "^2.6.0",
     "vue": "^2.4.2"

--- a/src/helpers/options.js
+++ b/src/helpers/options.js
@@ -1,4 +1,5 @@
+import merge from 'deepmerge'
+
 export function mergeOptions (obj, src) {
-  let mutableObj = Object.assign({}, obj)
-  return Object.assign(mutableObj, src)
+  return merge(obj, src)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,6 +1663,10 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.1.tgz#c053bf06fd7276f1994f70c09a0760cb61a56237"
+
 defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"


### PR DESCRIPTION
Fix for #190 

Replaced Object.assign with deepmerge to properly merge nested objects.
