### PR TITLE
Fix for lodash merge

### DIFF
--- a/src/helpers/options.js
+++ b/src/helpers/options.js
@@ -1,5 +1,5 @@
 import merge from 'lodash.merge'
 
 export function mergeOptions (obj, src) {
-  return merge(obj, src)
+  return merge(src, obj)
 }


### PR DESCRIPTION

### Fix or Enhancement?
Small fix for avoid merge of options in default Options object. Without it update, we have issues with dynamical update of chartjs options (for example, dynamical update amount of axies or any another). Because, lodash.merge is changed first object and any another changes has defaultObject with changes from previous.

- [x] All tests passed


### Environment
- OS: Write here
- NPM Version: Write here

