### PR TITLE
Add prop for inline plugins

### DIFF
--- a/src/BaseCharts/Bar.js
+++ b/src/BaseCharts/Bar.js
@@ -77,7 +77,7 @@ export default {
 
   methods: {
     addPlugin (plugin) {
-      this._plugins.push(plugin)
+      this.$data._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -86,7 +86,7 @@ export default {
           type: 'bar',
           data: data,
           options: chartOptions,
-          plugins: this._plugins
+          plugins: this.$data._plugins
         }
       )
     }

--- a/src/BaseCharts/Bar.js
+++ b/src/BaseCharts/Bar.js
@@ -41,6 +41,12 @@ export default {
     },
     styles: {
       type: Object
+    },
+    plugins: {
+      type: Array,
+      default () {
+        return []
+      }
     }
   },
   data () {
@@ -65,13 +71,13 @@ export default {
           }]
         }
       },
-      plugins: []
+      _plugins: this.plugins
     }
   },
 
   methods: {
     addPlugin (plugin) {
-      this.plugins.push(plugin)
+      this._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -80,7 +86,7 @@ export default {
           type: 'bar',
           data: data,
           options: chartOptions,
-          plugins: this.plugins
+          plugins: this._plugins
         }
       )
     }

--- a/src/BaseCharts/Bubble.js
+++ b/src/BaseCharts/Bubble.js
@@ -79,7 +79,7 @@ export default {
 
   methods: {
     addPlugin (plugin) {
-      this._plugins.push(plugin)
+      this.$data._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -89,7 +89,7 @@ export default {
           type: 'bubble',
           data: data,
           options: chartOptions,
-          plugins: this._plugins
+          plugins: this.$data._plugins
         }
       )
     }

--- a/src/BaseCharts/Bubble.js
+++ b/src/BaseCharts/Bubble.js
@@ -42,6 +42,12 @@ export default {
     },
     styles: {
       type: Object
+    },
+    plugins: {
+      type: Array,
+      default () {
+        return []
+      }
     }
   },
 
@@ -67,13 +73,13 @@ export default {
           }]
         }
       },
-      plugins: []
+      _plugins: this.plugins
     }
   },
 
   methods: {
     addPlugin (plugin) {
-      this.plugins.push(plugin)
+      this._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -83,7 +89,7 @@ export default {
           type: 'bubble',
           data: data,
           options: chartOptions,
-          plugins: this.plugins
+          plugins: this._plugins
         }
       )
     }

--- a/src/BaseCharts/Doughnut.js
+++ b/src/BaseCharts/Doughnut.js
@@ -42,6 +42,12 @@ export default {
     },
     styles: {
       type: Object
+    },
+    plugins: {
+      type: Array,
+      default () {
+        return []
+      }
     }
   },
 
@@ -50,13 +56,13 @@ export default {
       _chart: null,
       defaultOptions: {
       },
-      plugins: []
+      _plugins: this.plugins
     }
   },
 
   methods: {
     addPlugin (plugin) {
-      this.plugins.push(plugin)
+      this._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -66,7 +72,7 @@ export default {
           type: 'doughnut',
           data: data,
           options: chartOptions,
-          plugins: this.plugins
+          plugins: this._plugins
         }
       )
     }

--- a/src/BaseCharts/Doughnut.js
+++ b/src/BaseCharts/Doughnut.js
@@ -62,7 +62,7 @@ export default {
 
   methods: {
     addPlugin (plugin) {
-      this._plugins.push(plugin)
+      this.$data._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -72,7 +72,7 @@ export default {
           type: 'doughnut',
           data: data,
           options: chartOptions,
-          plugins: this._plugins
+          plugins: this.$data._plugins
         }
       )
     }

--- a/src/BaseCharts/HorizontalBar.js
+++ b/src/BaseCharts/HorizontalBar.js
@@ -79,7 +79,7 @@ export default {
 
   methods: {
     addPlugin (plugin) {
-      this._plugins.push(plugin)
+      this.$data._plugins.push(plugin)
     },
     renderChart (data, options, type) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -88,7 +88,7 @@ export default {
           type: 'horizontalBar',
           data: data,
           options: chartOptions,
-          plugins: this._plugins
+          plugins: this.$data._plugins
         }
       )
     }

--- a/src/BaseCharts/HorizontalBar.js
+++ b/src/BaseCharts/HorizontalBar.js
@@ -42,6 +42,12 @@ export default {
     },
     styles: {
       type: Object
+    },
+    plugins: {
+      type: Array,
+      default () {
+        return []
+      }
     }
   },
 
@@ -67,13 +73,13 @@ export default {
           }]
         }
       },
-      plugins: []
+      _plugins: this.plugins
     }
   },
 
   methods: {
     addPlugin (plugin) {
-      this.plugins.push(plugin)
+      this._plugins.push(plugin)
     },
     renderChart (data, options, type) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -82,7 +88,7 @@ export default {
           type: 'horizontalBar',
           data: data,
           options: chartOptions,
-          plugins: this.plugins
+          plugins: this._plugins
         }
       )
     }

--- a/src/BaseCharts/Line.js
+++ b/src/BaseCharts/Line.js
@@ -77,7 +77,7 @@ export default {
 
   methods: {
     addPlugin (plugin) {
-      this._plugins.push(plugin)
+      this.$data._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -87,7 +87,7 @@ export default {
           type: 'line',
           data: data,
           options: chartOptions,
-          plugins: this._plugins
+          plugins: this.$data._plugins
         }
       )
     }

--- a/src/BaseCharts/Line.js
+++ b/src/BaseCharts/Line.js
@@ -42,6 +42,12 @@ export default {
     },
     styles: {
       type: Object
+    },
+    plugins: {
+      type: Array,
+      default () {
+        return []
+      }
     }
   },
 
@@ -65,13 +71,13 @@ export default {
           }]
         }
       },
-      plugins: []
+      _plugins: this.plugins
     }
   },
 
   methods: {
     addPlugin (plugin) {
-      this.plugins.push(plugin)
+      this._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -81,7 +87,7 @@ export default {
           type: 'line',
           data: data,
           options: chartOptions,
-          plugins: this.plugins
+          plugins: this._plugins
         }
       )
     }

--- a/src/BaseCharts/Pie.js
+++ b/src/BaseCharts/Pie.js
@@ -42,6 +42,12 @@ export default {
     },
     styles: {
       type: Object
+    },
+    plugins: {
+      type: Array,
+      default () {
+        return []
+      }
     }
   },
 
@@ -50,13 +56,13 @@ export default {
       _chart: null,
       defaultOptions: {
       },
-      plugins: []
+      _plugins: this.plugins
     }
   },
 
   methods: {
     addPlugin (plugin) {
-      this.plugins.push(plugin)
+      this._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -66,7 +72,7 @@ export default {
           type: 'pie',
           data: data,
           options: chartOptions,
-          plugins: this.plugins
+          plugins: this._plugins
         }
       )
     }

--- a/src/BaseCharts/Pie.js
+++ b/src/BaseCharts/Pie.js
@@ -62,7 +62,7 @@ export default {
 
   methods: {
     addPlugin (plugin) {
-      this._plugins.push(plugin)
+      this.$data._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -72,7 +72,7 @@ export default {
           type: 'pie',
           data: data,
           options: chartOptions,
-          plugins: this._plugins
+          plugins: this.$data._plugins
         }
       )
     }

--- a/src/BaseCharts/PolarArea.js
+++ b/src/BaseCharts/PolarArea.js
@@ -62,7 +62,7 @@ export default {
 
   methods: {
     addPlugin (plugin) {
-      this._plugins.push(plugin)
+      this.$data._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -72,7 +72,7 @@ export default {
           type: 'polarArea',
           data: data,
           options: chartOptions,
-          plugins: this._plugins
+          plugins: this.$data._plugins
         }
       )
     }

--- a/src/BaseCharts/PolarArea.js
+++ b/src/BaseCharts/PolarArea.js
@@ -42,6 +42,12 @@ export default {
     },
     styles: {
       type: Object
+    },
+    plugins: {
+      type: Array,
+      default () {
+        return []
+      }
     }
   },
 
@@ -50,13 +56,13 @@ export default {
       _chart: null,
       defaultOptions: {
       },
-      plugins: []
+      _plugins: this.plugins
     }
   },
 
   methods: {
     addPlugin (plugin) {
-      this.plugins.push(plugin)
+      this._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -66,7 +72,7 @@ export default {
           type: 'polarArea',
           data: data,
           options: chartOptions,
-          plugins: this.plugins
+          plugins: this._plugins
         }
       )
     }

--- a/src/BaseCharts/Radar.js
+++ b/src/BaseCharts/Radar.js
@@ -62,7 +62,7 @@ export default {
 
   methods: {
     addPlugin (plugin) {
-      this._plugins.push(plugin)
+      this.$data._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -72,7 +72,7 @@ export default {
           type: 'radar',
           data: data,
           options: chartOptions,
-          plugins: this._plugins
+          plugins: this.$data._plugins
         }
       )
     }

--- a/src/BaseCharts/Radar.js
+++ b/src/BaseCharts/Radar.js
@@ -42,6 +42,12 @@ export default {
     },
     styles: {
       type: Object
+    },
+    plugins: {
+      type: Array,
+      default () {
+        return []
+      }
     }
   },
 
@@ -50,13 +56,13 @@ export default {
       _chart: null,
       defaultOptions: {
       },
-      plugins: []
+      _plugins: this.plugins
     }
   },
 
   methods: {
     addPlugin (plugin) {
-      this.plugins.push(plugin)
+      this._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -66,7 +72,7 @@ export default {
           type: 'radar',
           data: data,
           options: chartOptions,
-          plugins: this.plugins
+          plugins: this._plugins
         }
       )
     }

--- a/src/BaseCharts/Scatter.js
+++ b/src/BaseCharts/Scatter.js
@@ -68,7 +68,7 @@ export default {
 
   methods: {
     addPlugin (plugin) {
-      this._plugins.push(plugin)
+      this.$data._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -78,7 +78,7 @@ export default {
           type: 'scatter',
           data: data,
           options: chartOptions,
-          plugins: this._plugins
+          plugins: this.$data._plugins
         }
       )
     }

--- a/src/BaseCharts/Scatter.js
+++ b/src/BaseCharts/Scatter.js
@@ -42,6 +42,12 @@ export default {
     },
     styles: {
       type: Object
+    },
+    plugins: {
+      type: Array,
+      default () {
+        return []
+      }
     }
   },
 
@@ -56,13 +62,13 @@ export default {
           }]
         }
       },
-      plugins: []
+      _plugins: this.plugins
     }
   },
 
   methods: {
     addPlugin (plugin) {
-      this.plugins.push(plugin)
+      this._plugins.push(plugin)
     },
     renderChart (data, options) {
       let chartOptions = mergeOptions(this.defaultOptions, options)
@@ -72,7 +78,7 @@ export default {
           type: 'scatter',
           data: data,
           options: chartOptions,
-          plugins: this.plugins
+          plugins: this._plugins
         }
       )
     }

--- a/test/unit/specs/Bar.spec.js
+++ b/test/unit/specs/Bar.spec.js
@@ -76,9 +76,31 @@ describe('BarChart', () => {
       components: { BarChart }
     }).$mount(el)
 
-    expect(vm.$children[0].plugins).to.exist
+    expect(vm.$children[0]._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0].plugins.length).to.equal(1)
+    expect(vm.$children[0]._plugins.length).to.equal(1)
+  })
+
+  it('should add inline plugins based on prop', () => {
+    const testPlugin = {
+      id: 'test'
+    }
+
+    const vm = new Vue({
+      render: function (createElement) {
+        return createElement(
+          BarChart, {
+            props: {
+              plugins: [testPlugin]
+            }
+          }
+        )
+      },
+      components: { BarChart }
+    }).$mount(el)
+
+    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0]._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Bar.spec.js
+++ b/test/unit/specs/Bar.spec.js
@@ -76,10 +76,10 @@ describe('BarChart', () => {
       components: { BarChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0].$data._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 
   it('should add inline plugins based on prop', () => {
@@ -100,7 +100,7 @@ describe('BarChart', () => {
       components: { BarChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins).to.exist
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Bubble.spec.js
+++ b/test/unit/specs/Bubble.spec.js
@@ -76,10 +76,10 @@ describe('BubbleChart', () => {
       components: { BubbleChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0].$data._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 
   it('should add inline plugins based on prop', () => {
@@ -100,7 +100,7 @@ describe('BubbleChart', () => {
       components: { BubbleChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins).to.exist
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Bubble.spec.js
+++ b/test/unit/specs/Bubble.spec.js
@@ -76,9 +76,31 @@ describe('BubbleChart', () => {
       components: { BubbleChart }
     }).$mount(el)
 
-    expect(vm.$children[0].plugins).to.exist
+    expect(vm.$children[0]._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0].plugins.length).to.equal(1)
+    expect(vm.$children[0]._plugins.length).to.equal(1)
+  })
+
+  it('should add inline plugins based on prop', () => {
+    const testPlugin = {
+      id: 'test'
+    }
+
+    const vm = new Vue({
+      render: function (createElement) {
+        return createElement(
+          BubbleChart, {
+            props: {
+              plugins: [testPlugin]
+            }
+          }
+        )
+      },
+      components: { BubbleChart }
+    }).$mount(el)
+
+    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0]._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Doughnut.spec.js
+++ b/test/unit/specs/Doughnut.spec.js
@@ -76,10 +76,10 @@ describe('DoughnutChart', () => {
       components: { DoughnutChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0].$data._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 
   it('should add inline plugins based on prop', () => {
@@ -100,7 +100,7 @@ describe('DoughnutChart', () => {
       components: { DoughnutChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins).to.exist
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Doughnut.spec.js
+++ b/test/unit/specs/Doughnut.spec.js
@@ -76,9 +76,31 @@ describe('DoughnutChart', () => {
       components: { DoughnutChart }
     }).$mount(el)
 
-    expect(vm.$children[0].plugins).to.exist
+    expect(vm.$children[0]._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0].plugins.length).to.equal(1)
+    expect(vm.$children[0]._plugins.length).to.equal(1)
+  })
+
+  it('should add inline plugins based on prop', () => {
+    const testPlugin = {
+      id: 'test'
+    }
+
+    const vm = new Vue({
+      render: function (createElement) {
+        return createElement(
+          DoughnutChart, {
+            props: {
+              plugins: [testPlugin]
+            }
+          }
+        )
+      },
+      components: { DoughnutChart }
+    }).$mount(el)
+
+    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0]._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/HorizontalBar.spec.js
+++ b/test/unit/specs/HorizontalBar.spec.js
@@ -76,10 +76,10 @@ describe('HorizontalBarChart', () => {
       components: { HorizontalBarChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0].$data._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 
   it('should add inline plugins based on prop', () => {
@@ -100,7 +100,7 @@ describe('HorizontalBarChart', () => {
       components: { HorizontalBarChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins).to.exist
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/HorizontalBar.spec.js
+++ b/test/unit/specs/HorizontalBar.spec.js
@@ -76,9 +76,31 @@ describe('HorizontalBarChart', () => {
       components: { HorizontalBarChart }
     }).$mount(el)
 
-    expect(vm.$children[0].plugins).to.exist
+    expect(vm.$children[0]._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0].plugins.length).to.equal(1)
+    expect(vm.$children[0]._plugins.length).to.equal(1)
+  })
+
+  it('should add inline plugins based on prop', () => {
+    const testPlugin = {
+      id: 'test'
+    }
+
+    const vm = new Vue({
+      render: function (createElement) {
+        return createElement(
+          HorizontalBarChart, {
+            props: {
+              plugins: [testPlugin]
+            }
+          }
+        )
+      },
+      components: { HorizontalBarChart }
+    }).$mount(el)
+
+    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0]._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Line.spec.js
+++ b/test/unit/specs/Line.spec.js
@@ -76,9 +76,31 @@ describe('LineChart', () => {
       components: { LineChart }
     }).$mount(el)
 
-    expect(vm.$children[0].plugins).to.exist
+    expect(vm.$children[0]._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0].plugins.length).to.equal(1)
+    expect(vm.$children[0]._plugins.length).to.equal(1)
+  })
+
+  it('should add inline plugins based on prop', () => {
+    const testPlugin = {
+      id: 'test'
+    }
+
+    const vm = new Vue({
+      render: function (createElement) {
+        return createElement(
+          LineChart, {
+            props: {
+              plugins: [testPlugin]
+            }
+          }
+        )
+      },
+      components: { LineChart }
+    }).$mount(el)
+
+    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0]._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Line.spec.js
+++ b/test/unit/specs/Line.spec.js
@@ -76,10 +76,10 @@ describe('LineChart', () => {
       components: { LineChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0].$data._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 
   it('should add inline plugins based on prop', () => {
@@ -100,7 +100,7 @@ describe('LineChart', () => {
       components: { LineChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins).to.exist
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Pie.spec.js
+++ b/test/unit/specs/Pie.spec.js
@@ -75,10 +75,10 @@ describe('PieChart', () => {
       components: { PieChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0].$data._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 
   it('should add inline plugins based on prop', () => {
@@ -99,7 +99,7 @@ describe('PieChart', () => {
       components: { PieChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins).to.exist
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Pie.spec.js
+++ b/test/unit/specs/Pie.spec.js
@@ -75,9 +75,31 @@ describe('PieChart', () => {
       components: { PieChart }
     }).$mount(el)
 
-    expect(vm.$children[0].plugins).to.exist
+    expect(vm.$children[0]._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0].plugins.length).to.equal(1)
+    expect(vm.$children[0]._plugins.length).to.equal(1)
+  })
+
+  it('should add inline plugins based on prop', () => {
+    const testPlugin = {
+      id: 'test'
+    }
+
+    const vm = new Vue({
+      render: function (createElement) {
+        return createElement(
+          PieChart, {
+            props: {
+              plugins: [testPlugin]
+            }
+          }
+        )
+      },
+      components: { PieChart }
+    }).$mount(el)
+
+    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0]._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/PolarArea.spec.js
+++ b/test/unit/specs/PolarArea.spec.js
@@ -76,9 +76,31 @@ describe('PolarChart', () => {
       components: { PolarChart }
     }).$mount(el)
 
-    expect(vm.$children[0].plugins).to.exist
+    expect(vm.$children[0]._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0].plugins.length).to.equal(1)
+    expect(vm.$children[0]._plugins.length).to.equal(1)
+  })
+
+  it('should add inline plugins based on prop', () => {
+    const testPlugin = {
+      id: 'test'
+    }
+
+    const vm = new Vue({
+      render: function (createElement) {
+        return createElement(
+          PolarChart, {
+            props: {
+              plugins: [testPlugin]
+            }
+          }
+        )
+      },
+      components: { PolarChart }
+    }).$mount(el)
+
+    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0]._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/PolarArea.spec.js
+++ b/test/unit/specs/PolarArea.spec.js
@@ -76,10 +76,10 @@ describe('PolarChart', () => {
       components: { PolarChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0].$data._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 
   it('should add inline plugins based on prop', () => {
@@ -100,7 +100,7 @@ describe('PolarChart', () => {
       components: { PolarChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins).to.exist
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Radar.spec.js
+++ b/test/unit/specs/Radar.spec.js
@@ -75,9 +75,31 @@ describe('RadarChart', () => {
       components: { RadarChart }
     }).$mount(el)
 
-    expect(vm.$children[0].plugins).to.exist
+    expect(vm.$children[0]._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0].plugins.length).to.equal(1)
+    expect(vm.$children[0]._plugins.length).to.equal(1)
+  })
+
+  it('should add inline plugins based on prop', () => {
+    const testPlugin = {
+      id: 'test'
+    }
+
+    const vm = new Vue({
+      render: function (createElement) {
+        return createElement(
+          RadarChart, {
+            props: {
+              plugins: [testPlugin]
+            }
+          }
+        )
+      },
+      components: { RadarChart }
+    }).$mount(el)
+
+    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0]._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Radar.spec.js
+++ b/test/unit/specs/Radar.spec.js
@@ -75,10 +75,10 @@ describe('RadarChart', () => {
       components: { RadarChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0].$data._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 
   it('should add inline plugins based on prop', () => {
@@ -99,7 +99,7 @@ describe('RadarChart', () => {
       components: { RadarChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins).to.exist
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Scatter.spec.js
+++ b/test/unit/specs/Scatter.spec.js
@@ -76,10 +76,10 @@ describe('ScatterChart', () => {
       components: { ScatterChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0].$data._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 
   it('should add inline plugins based on prop', () => {
@@ -100,7 +100,7 @@ describe('ScatterChart', () => {
       components: { ScatterChart }
     }).$mount(el)
 
-    expect(vm.$children[0]._plugins).to.exist
-    expect(vm.$children[0]._plugins.length).to.equal(1)
+    expect(vm.$children[0].$data._plugins).to.exist
+    expect(vm.$children[0].$data._plugins.length).to.equal(1)
   })
 })

--- a/test/unit/specs/Scatter.spec.js
+++ b/test/unit/specs/Scatter.spec.js
@@ -76,9 +76,31 @@ describe('ScatterChart', () => {
       components: { ScatterChart }
     }).$mount(el)
 
-    expect(vm.$children[0].plugins).to.exist
+    expect(vm.$children[0]._plugins).to.exist
     vm.$children[0].addPlugin(testPlugin)
 
-    expect(vm.$children[0].plugins.length).to.equal(1)
+    expect(vm.$children[0]._plugins.length).to.equal(1)
+  })
+
+  it('should add inline plugins based on prop', () => {
+    const testPlugin = {
+      id: 'test'
+    }
+
+    const vm = new Vue({
+      render: function (createElement) {
+        return createElement(
+          ScatterChart, {
+            props: {
+              plugins: [testPlugin]
+            }
+          }
+        )
+      },
+      components: { ScatterChart }
+    }).$mount(el)
+
+    expect(vm.$children[0]._plugins).to.exist
+    expect(vm.$children[0]._plugins.length).to.equal(1)
   })
 })


### PR DESCRIPTION
### Enhancement


- [x] All tests passed


Implementation for feature-request #274.

Inline plugins can now be added using the `plugins` prop:
```javascript
// MonthlyIncome.vue
import { Line } from 'vue-chartjs'

export default {
  mixins: Line,
  props: ['data', 'options'],
  mounted () {
    this.renderChart(this.data, this.options)
  }
}
```

```vue
<template>
  <monthly-income :data={....}  :plugins="[chartJSPlugin]"/>
</template>

<script>
import MonthlyIncome from 'path/to/component/MonthlyIncome'

export default {
  components: { MonthlyIncome },
  ....
}
</script>
```

I've also updated the existing test cases (to reflect the change from `plugins` to `_plugins`) and added new test cases to test this feature.

I would've also helped update the docs, but unfortunately I only know 3 of the 8 languages.