### PR TITLE
🐛 Fix HorizontalBar inverted axes configuration

### DIFF
--- a/src/BaseCharts/HorizontalBar.js
+++ b/src/BaseCharts/HorizontalBar.js
@@ -57,19 +57,19 @@ export default {
       defaultOptions: {
         scales: {
           yAxes: [{
+            gridLines: {
+              display: false
+            },
+            categoryPercentage: 0.8,
+            barPercentage: 0.9
+          }],
+          xAxes: [{
             ticks: {
               beginAtZero: true
             },
             gridLines: {
               display: false
             }
-          }],
-          xAxes: [ {
-            gridLines: {
-              display: false
-            },
-            categoryPercentage: 0.5,
-            barPercentage: 0.2
           }]
         }
       },


### PR DESCRIPTION
### Fix

Hey!
Just a simple modification (Fix ?) to correct the inverted axis configuration on HorizontalBar.
I've put the default values for `categoryPercentage` and `barPercentage` to keep current behavior.

Thanks!
