### PR TITLE
fix(babel): fix decorator error in new version of babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,7 @@
         ]
       }
     }],
-    "@babel/stage-2"
+    ["@babel/stage-2",{"decoratorsLegacy":true}]
   ],
   "comments": false
 }


### PR DESCRIPTION

### Fix or Enhancement?
fix need {"decoratorsLegacy":true} in "@babel/stage-2" when we have a newest version of babel

- [ x] All tests passed


### Environment
- OS: Write here
- NPM Version: Write here

