### PR TITLE
Delete old chart.js instance first

### DIFF
--- a/src/BaseCharts.js
+++ b/src/BaseCharts.js
@@ -63,6 +63,7 @@ export function generateChart (chartId, chartType) {
         this.$data._plugins.push(plugin)
       },
       renderChart (data, options) {
+        if (this.$data._chart) this.$data._chart.destroy()
         this.$data._chart = new Chart(
           this.$refs.canvas.getContext('2d'), {
             type: chartType,


### PR DESCRIPTION
Before creating new instance we need to run destroy() on old instance if it is exists to avoid **Hovering over line chart shows old chart data** bug problem, which is described here:
https://github.com/chartjs/Chart.js/issues/920
https://github.com/jtblin/angular-chart.js/issues/187



### Fix or Enhancement?
Fix

- [x] All tests passed


### Environment
- OS: Windows 7
- NPM Version: 6.1.0

