### PR TITLE
Fixed docute version requested from unpkg (Last compatible v3.4.12)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,14 +6,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
   <meta name="description" content="vue-chartjs documentation with api reference and examples">
   <title>vue-chartjs documentation</title>
-  <link rel="stylesheet" href="https://unpkg.com/docute/dist/docute.css">
+  <link rel="stylesheet" href="https://unpkg.com/docute@3.4.12/dist/docute.css">
 </head>
 <body>
   <!-- don't remove this part start -->
   <div id="app"></div>
   <script src="https://unpkg.com/docute-evanyou"></script>
-  <script src="https://unpkg.com/docute/plugins/docsearch.js"></script>
-  <script src="https://unpkg.com/docute/dist/docute.js"></script>
+  <script src="https://unpkg.com/docute@3.4.12/plugins/docsearch.js"></script>
+  <script src="https://unpkg.com/docute@3.4.12/dist/docute.js"></script>
   <script src="./config.js"></script>
   <!-- don't remove this part end -->
 </body>


### PR DESCRIPTION
Hi! The documentation is not working, because **docute** version changed and now the module is exported as "Docute" and not "docute" (docute last version is 4 and the documentation is requesting the latest version of docute, but the documentation works with docute 3)

So I added the specific version of docute to render the documentation.
Hope it helps you!
```

### Fix or Enhancement?
Its a FIX!

- [ Ok ] All tests passed

### Environment
- OS: Ubuntu 16.0.4
- NPM Version: 6.1.0

```