### PR TITLE
Update package.json.  Bump chart.js version to 2.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@babel/preset-stage-2": "^7.0.0-beta.42",
     "babel-loader": "8.0.0-beta.0",
     "chai": "^3.5.0",
-    "chart.js": "2.7.2",
+    "chart.js": "2.7.3",
     "chromedriver": "^2.28.0",
     "connect-history-api-fallback": "^1.1.0",
     "cross-env": "^5.1.1",


### PR DESCRIPTION
Update package.json.  Bump chart.js version to 2.7.3.  

We're using vue-chartjs in a web component.   Shadow DOM support was added in Version 2.7.3 https://github.com/chartjs/Chart.js/pull/5585 .



### Fix or Enhancement?


- [ ] All tests passed


### Environment
- OS: Write here
- NPM Version: Write here

