### PR TITLE
Update README.md

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -370,7 +370,7 @@ Then create a container component, which handles your api call or vuex connectio
 </template>
 
 <script>
-import LineChart from './LineChart.vue'
+import LineChart from './Chart.vue'
 
 export default {
   name: 'LineChartContainer',


### PR DESCRIPTION
changed file reference in readme.md
Chart with API data
describes two file Chart.vue and ChartContainer.vue, so i guess the 
import LineChart from './LineChart.vue' should be import LineChart from './Chart.vue'

