### PR TITLE
docs: enhance search on the documentation

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -91,6 +91,10 @@ module.exports = {
           }
         },
       }
+    },
+    algolia: {
+      indexName: 'vue-chartjs',
+      apiKey: 'b3544f7387612693644777553675d56a'
     }
   },
   locales: {


### PR DESCRIPTION
This PR enable the vuepress recommended search DocSearch on your website such as https://cli.vuejs.org/
[![Demo](https://cl.ly/c31ef642545a/download/Screen%20Recording%202019-05-29%20at%2009.31%20AM.gif)](https://vue-chartjs-docsearch.surge.sh/) 

You can [try it live here](https://vue-chartjs-docsearch.surge.sh/) 