### PR TITLE
docs: Update 'More info here' link in readme doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ However, keep in mind the limitations of vue and javascript for mutations on arr
 **It is important that you pass your options in a local variable named `options`!**
 The reason is that if the mixin re-renders the chart it calls `this.renderChart(this.chartData, this.options)` so don't pass in the options object directly or it will be ignored.
 
-More info [here](http://vue-chartjs.org/#/home?id=reactive-data)
+More info [here](https://vue-chartjs.org/guide/#updating-charts)
 
 ```javascript
 // MonthlyIncome.js


### PR DESCRIPTION

### Enhancement
Under the Reactive data section in the readme, the _More info here_ link only takes the reader to the main vue-chartjs homepage.

I'm proposing that since this section is talking about updating data, we can direct users to the Updating charts section of the docs, since it's still within the same realm and will provide meaningful context for developers who are looking for this info.

- [ ] All tests passed 
(not needed since it's just documentation)


### Environment
- OS: Mac OS mojave
- NPM Version: 6.11.3


:pray:
