### PR TITLE
Comma is missing only in japanese docs.

### DIFF
--- a/docs/ja/guide/README.md
+++ b/docs/ja/guide/README.md
@@ -346,7 +346,7 @@ export default {
     chartdata: {
       type: Object,
       default: null
-    }
+    },
     options: {
       type: Object,
       default: null


### PR DESCRIPTION
It can be same as **Chart with props** code.