### PR TITLE
Add scarf-js for installation analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ If you're looking for v1 check this [branch](https://github.com/apertureless/vue
 - **yarn** install: `yarn add vue-chartjs chart.js`
 - **npm** install: `npm install vue-chartjs chart.js --save`
 
+Please note: vue-chartjs uses [Scarf](https://www.npmjs.com/package/@scarf/scarf) to collect anonymized installation analytics. These analytics help support the maintainers of this library. However, if you'd like to opt out, you can do so by setting `scarfSettings.enabled = false` in your project's package.json. Alternatively, you can set the environment variable `SCARF_ANALYTICS=false`.
+
 Or if you want to use it directly in the browser add
 
 ```html

--- a/package.json
+++ b/package.json
@@ -147,5 +147,8 @@
       "webpack",
       "webpack-merge"
     ]
+  },
+  "dependencies": {
+    "@scarf/scarf": "^1.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1426,6 +1426,11 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz#54c5a964462be3d4d78af631363c18d6fa91ac26"
   integrity sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw==
 
+"@scarf/scarf@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.0.4.tgz#d7c09e7d38428123df18a8d83a4bb5d09517d952"
+  integrity sha512-lkhjzeYyYAG4VvdrjvbZCOYzXH5vCwfzYj9xJ4zHDgyYIOzObZwcsbW6W1q5Z4tywrb14oG/tfsFAMMQPCTFqw==
+
 "@shellscape/koa-send@^4.1.0":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@shellscape/koa-send/-/koa-send-4.1.3.tgz#1a7c8df21f63487e060b7bfd8ed82e1d3c4ae0b0"
@@ -1443,6 +1448,13 @@
   dependencies:
     "@shellscape/koa-send" "^4.1.0"
     debug "^2.6.8"
+
+"@types/chart.js@^2.7.55":
+  version "2.9.20"
+  resolved "https://registry.yarnpkg.com/@types/chart.js/-/chart.js-2.9.20.tgz#db503fc0d478d1d2a99eb0099d5c2b9c77599931"
+  integrity sha512-Xv4dd+DYqtTdUWbDIwaDEFtUIFwoQN44wiDDrWXdJtfGtOFlFIxXrsu8D+XJCS9o7mZbW29X8vPptwVrduz4JA==
+  dependencies:
+    moment "^2.10.2"
 
 "@vue/babel-preset-app@3.0.0-beta.11":
   version "3.0.0-beta.11"
@@ -2904,10 +2916,10 @@ change-case@3.0.x:
     upper-case "^1.1.1"
     upper-case-first "^1.1.0"
 
-chart.js@2.7.3:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.7.3.tgz#cdb61618830bf216dc887e2f7b1b3c228b73c57e"
-  integrity sha512-3+7k/DbR92m6BsMUYP6M0dMsMVZpMnwkUyNSAbqolHKsbIzH2Q4LWVEHHYq7v0fmEV8whXE0DrjANulw9j2K5g==
+chart.js@^2.8.0:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.9.3.tgz#ae3884114dafd381bc600f5b35a189138aac1ef7"
+  integrity sha512-+2jlOobSk52c1VU6fzkh3UwqHMdSlgH1xFv9FKMqHiNCpXsGPQa/+81AFa+i3jZ253Mq9aAycPwDjnn1XbRNNw==
   dependencies:
     chartjs-color "^2.1.0"
     moment "^2.10.2"


### PR DESCRIPTION

### Fix or Enhancement?

Enhancement

- [x] All tests passed


### Environment
- OS: Mac OS Mojave 10.14.6
- NPM Version: 6.9.0

Thanks for all the work on vue-chartjs, I'm a happy user :).  In efforts to help support the project, this change adds a dependency on [scarf-js](https://github.com/scarf-sh/scarf-js) so you can collect anonymized installation analytics. When vue-chartjs is installed, Scarf-js will transparently inform the user about the analytics and how they can opt out if they choose to. By adding this dependency, the metrics you'll collect will provide insight into how your package is being and by which companies, which can be used as public validation for your package in production. The data will be available to you and any co-maintainers you wish to authorize on https://scarf.sh (which is a vue-chartjs user!). If you're interested, the Scarf team can reach out to these companies to drive more financial support for your package through GitHub Sponsors or even help set up support contracts.
