### PR TITLE
Fix "TypeError: Cannot read property 'getContext' of undefined"

### DIFF
--- a/src/BaseCharts.js
+++ b/src/BaseCharts.js
@@ -69,6 +69,7 @@ export function generateChart (chartId, chartType) {
       },
       renderChart (data, options) {
         if (this.$data._chart) this.$data._chart.destroy()
+        if (!this.$refs.canvas) throw "No canvas found. If you are using a VUE compiler remove the `<template></template>` tags from your component."
         this.$data._chart = new Chart(
           this.$refs.canvas.getContext('2d'), {
             type: chartType,


### PR DESCRIPTION
The error ""TypeError: Cannot read property 'getContext' of undefined"" has appeared several times (see https://github.com/apertureless/vue-chartjs/issues/156, https://github.com/apertureless/vue-chartjs/issues/350 and a few others on StackOverflow)

I think this `throw` description help devs address the issue quickly.



### Fix or Enhancement?


- [ ] All tests passed


### Environment
- OS: Write here
- NPM Version: Write here

