### PR TITLE
chore(docs): Fix readme typescript example type error

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ or in TypeScript
 
 ```ts
 // CommitChart.ts
+import { Component, Mixins } from 'vue-property-decorator'
 import { Bar, mixins } from 'vue-chartjs';
 import { Component } from 'vue-property-decorator';
 
@@ -118,7 +119,7 @@ import { Component } from 'vue-property-decorator';
     extends: Bar, // this is important to add the functionality to your component
     mixins: [mixins.reactiveProp]
 })
-export default class CommitChart extends Vue<Bar> {
+export default class CommitChart extends Mixins(mixins.reactiveProp, Bar) {
   mounted () {
     // Overwriting base render method with actual data.
     this.renderChart({


### PR DESCRIPTION
## What does this PR do?

Resolves #638

### What was the problem?

The problem was that the example was causing typescript error as described in
https://github.com/apertureless/vue-chartjs/issues/638

### What is the solution?

The solution is updating the docs as propsed in https://github.com/apertureless/vue-chartjs/issues/638#issuecomment-704894493




### Fix or Enhancement?

Fix

- [x] All tests passed


### Environment
- OS: Any
- NPM Version: Any

