### PR TITLE
Import and register chartjs 3 components

### DIFF
--- a/src/BaseCharts.js
+++ b/src/BaseCharts.js
@@ -73,7 +73,7 @@ export function generateChart (chartId, chartType) {
       renderChart (data, options) {
         if (this.$data._chart) this.$data._chart.destroy()
         if (!this.$refs.canvas) throw new Error('Please remove the <template></template> tags from your chart component. See https://vue-chartjs.org/guide/#vue-single-file-components')
-        this.$data._chart = new Chart(
+        this.$data._chart = new ChartJs.Chart(
           this.$refs.canvas.getContext('2d'), {
             type: chartType,
             data: data,

--- a/src/BaseCharts.js
+++ b/src/BaseCharts.js
@@ -1,54 +1,7 @@
 
-import {
-  Arc,
-  BarController,
-  BubbleController,
-  CategoryScale,
-  Chart,
-  DoughnutController,
-  Filler,
-  Legend,
-  Line as ChartLine,
-  LineController,
-  LinearScale,
-  LogarithmicScale,
-  PieController,
-  Point,
-  PolarAreaController,
-  RadarController,
-  RadialLinearScale,
-  Rectangle,
-  ScatterController,
-  TimeScale,
-  TimeSeriesScale,
-  Title,
-  Tooltip
-} from 'chart.js'
+import * as ChartJs from 'chart.js'
 
-Chart.register(
-  Arc,
-  BarController,
-  BubbleController,
-  CategoryScale,
-  DoughnutController,
-  Filler,
-  Legend,
-  ChartLine,
-  LineController,
-  LinearScale,
-  LogarithmicScale,
-  PieController,
-  Point,
-  PolarAreaController,
-  RadarController,
-  RadialLinearScale,
-  Rectangle,
-  ScatterController,
-  TimeScale,
-  TimeSeriesScale,
-  Title,
-  Tooltip
-)
+ChartJs.Chart.register.apply(null, Object.values(ChartJs).filter((chartClass) => (chartClass.id)))
 
 export function generateChart (chartId, chartType) {
   return {

--- a/src/BaseCharts.js
+++ b/src/BaseCharts.js
@@ -1,4 +1,6 @@
-import Chart from 'chart.js'
+import { Arc, BarController, BubbleController, CategoryScale, Chart, DoughnutController, Filler, Legend, Line as ChartLine, LineController, LinearScale, LogarithmicScale, PieController, Point, PolarAreaController, RadarController, RadialLinearScale, Rectangle, ScatterController, TimeScale, TimeSeriesScale, Title, Tooltip } from 'chart.js';
+
+Chart.register(Arc, BarController, BubbleController, CategoryScale, DoughnutController, Filler, Legend, ChartLine, LineController, LinearScale, LogarithmicScale, PieController, Point, PolarAreaController, RadarController, RadialLinearScale, Rectangle, ScatterController, TimeScale, TimeSeriesScale, Title, Tooltip);
 
 export function generateChart (chartId, chartType) {
   return {

--- a/src/BaseCharts.js
+++ b/src/BaseCharts.js
@@ -1,3 +1,4 @@
+
 import {
   Arc,
   BarController,
@@ -14,7 +15,7 @@ import {
   PieController,
   Point,
   PolarAreaController,
-  RadarController
+  RadarController,
   RadialLinearScale,
   Rectangle,
   ScatterController,
@@ -32,14 +33,14 @@ Chart.register(
   DoughnutController,
   Filler,
   Legend,
-  Line as ChartLine,
+  ChartLine,
   LineController,
   LinearScale,
   LogarithmicScale,
   PieController,
   Point,
   PolarAreaController,
-  RadarController
+  RadarController,
   RadialLinearScale,
   Rectangle,
   ScatterController,

--- a/src/BaseCharts.js
+++ b/src/BaseCharts.js
@@ -1,6 +1,53 @@
-import { Arc, BarController, BubbleController, CategoryScale, Chart, DoughnutController, Filler, Legend, Line as ChartLine, LineController, LinearScale, LogarithmicScale, PieController, Point, PolarAreaController, RadarController, RadialLinearScale, Rectangle, ScatterController, TimeScale, TimeSeriesScale, Title, Tooltip } from 'chart.js';
+import {
+  Arc,
+  BarController,
+  BubbleController,
+  CategoryScale,
+  Chart,
+  DoughnutController,
+  Filler,
+  Legend,
+  Line as ChartLine,
+  LineController,
+  LinearScale,
+  LogarithmicScale,
+  PieController,
+  Point,
+  PolarAreaController,
+  RadarController
+  RadialLinearScale,
+  Rectangle,
+  ScatterController,
+  TimeScale,
+  TimeSeriesScale,
+  Title,
+  Tooltip
+} from 'chart.js'
 
-Chart.register(Arc, BarController, BubbleController, CategoryScale, DoughnutController, Filler, Legend, ChartLine, LineController, LinearScale, LogarithmicScale, PieController, Point, PolarAreaController, RadarController, RadialLinearScale, Rectangle, ScatterController, TimeScale, TimeSeriesScale, Title, Tooltip);
+Chart.register(
+  Arc,
+  BarController,
+  BubbleController,
+  CategoryScale,
+  DoughnutController,
+  Filler,
+  Legend,
+  Line as ChartLine,
+  LineController,
+  LinearScale,
+  LogarithmicScale,
+  PieController,
+  Point,
+  PolarAreaController,
+  RadarController
+  RadialLinearScale,
+  Rectangle,
+  ScatterController,
+  TimeScale,
+  TimeSeriesScale,
+  Title,
+  Tooltip
+)
 
 export function generateChart (chartId, chartType) {
   return {


### PR DESCRIPTION
Imports all chartjs 3 components and registers them.

Unfortunately this would mean that the v3 version would not be compatible with chartjs 2, so not sure if you want to merge this like this, or if possible add some conditional so vue-chartjs works with both 2 and 3, or if that matters to this project (maybe only supporting 3 once it's out is all that's needed for a new version of vue-chartjs?)

All the same, thanks for putting this library together :)