### PR TITLE
Explicit example for reactivity with store state

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,62 @@ export default {
     this.renderChart(this.chartData, this.options)
   }
 }
+### Out-of-the-box Store Reactivity
+
+Reactivity with a central store is a breeze. Just have the filler method return the datacollection you'll use for the chart. Naturally, you'll have to define your getters in the store for your data:
+
+E.g. Bar chart as module import:
+
+```javascript
+// BarChart.js
+import { Bar, mixins } from "vue-chartjs";
+
+export default {
+  extends: Bar,
+  mixins: [mixins.reactiveProp],
+  props: ["chartData", "options"],
+  mounted() {
+    this.renderChart(this.chartData, this.options);
+  },
+};
+```
+
+Vue Single File Component:
+
+```html
+<template>
+  <div class="small">
+    <bar-chart :chart-data="fillData()"></bar-chart>
+  </div>
+</template>
+
+<script>
+  import store from "../store/index"; // assuming standard store setup
+
+  import BarChart from "./BarChart.js";
+
+  export default {
+    components: {
+      BarChart,
+    },
+
+    store,
+
+    methods: {
+      fillData() {
+        return {
+          labels: ["First Column"],
+          datasets: [
+            {
+              label: "First Column",
+              data: [this.$store.getters.yourAwesomeData],
+            },
+          ],
+        };
+      },
+    },
+  };
+</script>
 ```
 
 ## Single File Components


### PR DESCRIPTION
Adds an explicit example detailing reactive chart changes to changes in store state. Avoids 'computed' caveat. Much quicker onboarding of developers new to Vue

### Enhancement

Documentation to include an example of how to implement store reactivity. Especially for developers new to the Vue framework. This stackoverflow [question](https://stackoverflow.com/questions/61345505/vue-chart-js-vuex-chart-not-updating-when-vuex-state-changes/65416257#65416257) shows the issue. I can echo this sentiment personally.
