### PR TITLE
Fix typo in README category title

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -469,7 +469,7 @@ export default {
 }
 ```
 
-## Resourcess
+## Resources
 
 Here are some resources, such as tutorials, on how to use `vue-chartjs`:
 


### PR DESCRIPTION
Double 's' on Resources

