### PR TITLE
Fix peerDependencies to avoid v3 conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "docs:build": "vuepress build docs"
   },
   "peerDependencies": {
-    "chart.js": ">= 2.5"
+    "chart.js": "^2.5"
   },
   "dependencies": {
     "@types/chart.js": "^2.7.55"


### PR DESCRIPTION
The peer dependency should not allow the major version 3 to be installed (which it currently does)

Limiting it to Pre 3.0 will avoid incompatibility till v3 support is rolled out



### Fix or Enhancement?


- [ ] All tests passed


### Environment
- OS: Write here
- NPM Version: Write here

