### PR TITLE
fix extra letter in documentation

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -469,7 +469,7 @@ export default {
 }
 ```
 
-## Resourcess
+## Resources
 
 Here are some resources, such as tutorials, on how to use `vue-chartjs`:
 


### PR DESCRIPTION
# fix extra letter in documentation
- changed `Resourcess` title to `Resources`



### Enhancement


- [X] All tests passed

### Environment
- OS: Mac OS
- NPM Version: not applicable

