### PR TITLE
add missed export for legacy charts generateChart func

### DIFF
--- a/legacy/src/Charts.js
+++ b/legacy/src/Charts.js
@@ -228,5 +228,6 @@ export default {
   Pie,
   PolarArea,
   Radar,
-  Scatter
+  Scatter,
+  generateChart
 }

--- a/legacy/src/index.js
+++ b/legacy/src/index.js
@@ -6,7 +6,18 @@ import {
   PolarArea,
   Radar,
   Bubble,
-  Scatter
+  Scatter,
+  generateChart
 } from './Charts.js'
 
-export { Bar, Doughnut, Line, Pie, PolarArea, Radar, Bubble, Scatter }
+export {
+  Bar,
+  Doughnut,
+  Line,
+  Pie,
+  PolarArea,
+  Radar,
+  Bubble,
+  Scatter,
+  generateChart
+}


### PR DESCRIPTION
fix #783

### Fix or Enhancement?
fix https://github.com/apertureless/vue-chartjs/issues/783#issue-1183457021


- [x] All tests passed


### Environment
- OS: BigSur MacOs
- NPM Version: 8.5.1

