### PR TITLE
fix(types): fix chart plugins type

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {
@@ -183,8 +183,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'bar'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'bar'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/legacy/sandboxes/bar/src/components/Bar.vue
+++ b/legacy/sandboxes/bar/src/components/Bar.vue
@@ -58,8 +58,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/sandboxes/bubble/src/components/Bubble.vue
+++ b/legacy/sandboxes/bubble/src/components/Bubble.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/sandboxes/doughnut/src/components/Doughnut.vue
+++ b/legacy/sandboxes/doughnut/src/components/Doughnut.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/sandboxes/line/src/components/Line.vue
+++ b/legacy/sandboxes/line/src/components/Line.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/sandboxes/pie/src/components/Pie.vue
+++ b/legacy/sandboxes/pie/src/components/Pie.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/sandboxes/polar-area/src/components/PolarArea.vue
+++ b/legacy/sandboxes/polar-area/src/components/PolarArea.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/sandboxes/radar/src/components/Radar.vue
+++ b/legacy/sandboxes/radar/src/components/Radar.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/sandboxes/scatter/src/components/Scatter.vue
+++ b/legacy/sandboxes/scatter/src/components/Scatter.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/src/Charts.js
+++ b/legacy/src/Charts.js
@@ -14,7 +14,6 @@ import {
   chartCreate,
   chartDestroy,
   chartUpdate,
-  getChartOptions,
   getChartData,
   setChartLabels,
   setChartDatasets,
@@ -59,8 +58,8 @@ export function generateChart(chartId, chartType, chartController) {
         default: () => {}
       },
       plugins: {
-        type: Object,
-        default: () => {}
+        type: Array,
+        default: () => []
       }
     },
     data() {
@@ -100,7 +99,8 @@ export function generateChart(chartId, chartType, chartController) {
             this.$data._chart = new ChartJS(canvasEl2DContext, {
               type: chartType,
               data: chartData,
-              options: getChartOptions(options, this.plugins)
+              options,
+              plugins: this.plugins
             })
           }
         }

--- a/legacy/test/Bar.spec.js
+++ b/legacy/test/Bar.spec.js
@@ -31,15 +31,13 @@ describe('LegacyBar', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      propsData: { plugins: testPlugin }
+      propsData: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/legacy/test/Bubble.spec.js
+++ b/legacy/test/Bubble.spec.js
@@ -32,15 +32,13 @@ describe('LegacyBubble', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      propsData: { plugins: testPlugin }
+      propsData: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/legacy/test/Doughnut.spec.js
+++ b/legacy/test/Doughnut.spec.js
@@ -32,15 +32,13 @@ describe('LegacyDoughnut', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      propsData: { plugins: testPlugin }
+      propsData: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/legacy/test/Line.spec.js
+++ b/legacy/test/Line.spec.js
@@ -31,15 +31,13 @@ describe('LegacyLine', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      propsData: { plugins: testPlugin }
+      propsData: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/legacy/test/Pie.spec.js
+++ b/legacy/test/Pie.spec.js
@@ -31,15 +31,13 @@ describe('LegacyPie', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      propsData: { plugins: testPlugin }
+      propsData: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/legacy/test/PolarArea.spec.js
+++ b/legacy/test/PolarArea.spec.js
@@ -32,15 +32,13 @@ describe('LegacyPolarArea', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      propsData: { plugins: testPlugin }
+      propsData: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/legacy/test/Radar.spec.js
+++ b/legacy/test/Radar.spec.js
@@ -32,15 +32,13 @@ describe('LegacyRadar', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      propsData: { plugins: testPlugin }
+      propsData: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/legacy/test/Scatter.spec.js
+++ b/legacy/test/Scatter.spec.js
@@ -32,15 +32,13 @@ describe('LegacyScatter', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      propsData: { plugins: testPlugin }
+      propsData: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/legacy/test/examples/Bar.vue
+++ b/legacy/test/examples/Bar.vue
@@ -58,8 +58,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/test/examples/Bubble.vue
+++ b/legacy/test/examples/Bubble.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/test/examples/Doughnut.vue
+++ b/legacy/test/examples/Doughnut.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/test/examples/Line.vue
+++ b/legacy/test/examples/Line.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/test/examples/Pie.vue
+++ b/legacy/test/examples/Pie.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/test/examples/PolarArea.vue
+++ b/legacy/test/examples/PolarArea.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/test/examples/Radar.vue
+++ b/legacy/test/examples/Radar.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/legacy/test/examples/Scatter.vue
+++ b/legacy/test/examples/Scatter.vue
@@ -57,8 +57,8 @@ export default {
       default: () => {}
     },
     plugins: {
-      type: Object,
-      default: () => {}
+      type: Array,
+      default: () => []
     }
   },
   data() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "vue-chartjs",
   "version": "4.0.2",
-  "packageManager": "pnpm@6.32.2",
   "description": "Vue.js wrapper for chart.js for creating beautiful charts.",
   "author": "Jakub Juszczak <jakub@posteo.de>",
   "homepage": "http://vue-chartjs.org",

--- a/sandboxes/bar/src/components/barChart.ts
+++ b/sandboxes/bar/src/components/barChart.ts
@@ -10,7 +10,7 @@ import {
   BarElement,
   CategoryScale,
   LinearScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale)
@@ -42,8 +42,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'bar'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'bar'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/sandboxes/bubble/src/components/bubbleChart.ts
+++ b/sandboxes/bubble/src/components/bubbleChart.ts
@@ -9,7 +9,7 @@ import {
   Legend,
   PointElement,
   LinearScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, PointElement, LinearScale)
@@ -41,8 +41,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'bubble'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'bubble'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/sandboxes/custom/src/components/customChart.ts
+++ b/sandboxes/custom/src/components/customChart.ts
@@ -11,7 +11,7 @@ import {
   PointElement,
   CategoryScale,
   LinearScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(
@@ -80,8 +80,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'line'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'line'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/sandboxes/doughnut/src/components/doughnutChart.ts
+++ b/sandboxes/doughnut/src/components/doughnutChart.ts
@@ -8,7 +8,7 @@ import {
   Legend,
   ArcElement,
   CategoryScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, ArcElement, CategoryScale)
@@ -40,8 +40,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'doughnut'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'doughnut'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/sandboxes/line/src/components/lineChart.ts
+++ b/sandboxes/line/src/components/lineChart.ts
@@ -8,7 +8,7 @@ import {
   Legend,
   LineElement,
   LinearScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, LineElement, LinearScale)
@@ -40,8 +40,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'line'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'line'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/sandboxes/pie/src/components/pieChart.ts
+++ b/sandboxes/pie/src/components/pieChart.ts
@@ -8,7 +8,7 @@ import {
   Legend,
   ArcElement,
   CategoryScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, ArcElement, CategoryScale)
@@ -40,8 +40,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'pie'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'pie'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/sandboxes/polar-area/src/components/polarAreaChart.ts
+++ b/sandboxes/polar-area/src/components/polarAreaChart.ts
@@ -8,7 +8,7 @@ import {
   Legend,
   ArcElement,
   RadialLinearScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, ArcElement, RadialLinearScale)
@@ -40,8 +40,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'polarArea'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'polarArea'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/sandboxes/radar/src/components/radarChart.ts
+++ b/sandboxes/radar/src/components/radarChart.ts
@@ -8,7 +8,7 @@ import {
   Legend,
   PointElement,
   RadialLinearScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, PointElement, RadialLinearScale)
@@ -40,8 +40,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'radar'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'radar'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/sandboxes/reactive-prop/src/components/reactivePropChart.ts
+++ b/sandboxes/reactive-prop/src/components/reactivePropChart.ts
@@ -8,7 +8,7 @@ import {
   BarElement,
   CategoryScale,
   LinearScale,
-  PluginOptionsByType,
+  Plugin,
   ChartData,
   DefaultDataPoint
 } from 'chart.js'
@@ -48,8 +48,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'bar'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'bar'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/sandboxes/reactive/src/components/reactiveChart.ts
+++ b/sandboxes/reactive/src/components/reactiveChart.ts
@@ -8,7 +8,7 @@ import {
   BarElement,
   CategoryScale,
   LinearScale,
-  PluginOptionsByType,
+  Plugin,
   ChartData
 } from 'chart.js'
 
@@ -41,8 +41,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'bar'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'bar'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/sandboxes/scatter/src/components/scatterChart.ts
+++ b/sandboxes/scatter/src/components/scatterChart.ts
@@ -8,7 +8,7 @@ import {
   Legend,
   LineElement,
   CategoryScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, LineElement, CategoryScale)
@@ -40,8 +40,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'scatter'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'scatter'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/src/BaseCharts.ts
+++ b/src/BaseCharts.ts
@@ -14,8 +14,8 @@ import type {
   ChartType,
   ChartComponentLike,
   DefaultDataPoint,
-  PluginOptionsByType,
-  ChartOptions
+  ChartOptions,
+  Plugin
 } from 'chart.js'
 
 import {
@@ -35,7 +35,6 @@ import {
   chartCreate,
   chartDestroy,
   chartUpdate,
-  getChartOptions,
   getChartData,
   setChartLabels,
   setChartDatasets,
@@ -94,8 +93,8 @@ export const generateChart = <
         default: () => {}
       },
       plugins: {
-        type: Object as PropType<PluginOptionsByType<TType>>,
-        default: () => {}
+        type: Array as PropType<Plugin<TType>[]>,
+        default: () => []
       }
     },
     setup(props, context) {
@@ -127,7 +126,8 @@ export const generateChart = <
               {
                 type: chartType,
                 data: isProxy(data) ? new Proxy(chartData, {}) : chartData,
-                options: getChartOptions<TType>(options, props.plugins)
+                options,
+                plugins: props.plugins
               }
             )
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,9 +3,8 @@ import type {
   ChartType,
   ChartData,
   ChartOptions,
-  PluginChartOptions,
   DefaultDataPoint,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 import {
@@ -27,8 +26,6 @@ export type TChartData<
 
 export type TChartOptions<TType extends ChartType> = ChartOptions<TType>
 
-export type TChartPlugins<TType extends ChartType> = PluginChartOptions<TType>
-
 export type TypedChartJS<
   TType extends ChartType = ChartType,
   TData = DefaultDataPoint<TType>,
@@ -48,7 +45,7 @@ export interface IChartProps<
   height?: number
   cssClasses?: string
   styles?: Partial<CSSStyleDeclaration>
-  plugins?: PluginOptionsByType<TType>
+  plugins?: Plugin<TType>[]
 }
 
 export interface IChartComponentData<

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,4 @@
-import type {
-  ChartType,
-  ChartDataset,
-  DefaultDataPoint,
-  PluginOptionsByType
-} from 'chart.js'
+import type { ChartType, ChartDataset, DefaultDataPoint } from 'chart.js'
 
 import type { TChartData, TChartOptions, TypedChartJS } from './types'
 
@@ -75,27 +70,6 @@ export function getChartData<
 
   setChartDatasets(nextData, { ...data }, datasetIdKey)
   return nextData
-}
-
-export function getChartOptions<TType extends ChartType = ChartType>(
-  options?: TChartOptions<TType>,
-  plugins?: PluginOptionsByType<TType>
-): TChartOptions<TType> | undefined {
-  const chartOptions = options
-
-  if (
-    chartOptions !== undefined &&
-    'plugins' in chartOptions &&
-    typeof plugins !== 'undefined' &&
-    Object.keys(plugins).length > 0
-  ) {
-    chartOptions.plugins = {
-      ...chartOptions.plugins,
-      ...plugins
-    }
-  }
-
-  return chartOptions
 }
 
 export function setChartDatasets<

--- a/test/Bar.spec.ts
+++ b/test/Bar.spec.ts
@@ -31,15 +31,13 @@ describe('BarChart', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      props: { plugins: testPlugin }
+      props: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/test/Bubble.spec.ts
+++ b/test/Bubble.spec.ts
@@ -32,15 +32,13 @@ describe('BubbleChart', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      props: { plugins: testPlugin }
+      props: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/test/ChartsTypes.test-d.ts
+++ b/test/ChartsTypes.test-d.ts
@@ -1,11 +1,15 @@
 import { h } from 'vue'
 import { expectError } from 'tsd'
-import { PluginOptionsByType } from 'chart.js'
+import { Plugin } from 'chart.js'
 
 import { Bar, Radar, Scatter, Doughnut } from '../src'
 
 const chartData = {
   datasets: []
+}
+
+const testPlugin = {
+  id: 'test'
 }
 
 /**
@@ -14,12 +18,12 @@ const chartData = {
 
 h(Radar, {
   chartData,
-  plugins: {} as PluginOptionsByType<'radar'>
+  plugins: []
 })
 
 h(Scatter, {
   chartData,
-  plugins: {} as PluginOptionsByType<'scatter'>
+  plugins: []
 })
 
 h(Bar, {
@@ -30,7 +34,7 @@ h(Bar, {
 expectError(
   h(Scatter, {
     chartData,
-    plugins: {} as PluginOptionsByType<'bubble'>
+    plugins: [testPlugin] as Plugin<'bubble'>[]
   })
 )
 

--- a/test/Doughnut.spec.ts
+++ b/test/Doughnut.spec.ts
@@ -32,15 +32,13 @@ describe('DoughnutChart', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      props: { plugins: testPlugin }
+      props: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/test/Line.spec.ts
+++ b/test/Line.spec.ts
@@ -31,15 +31,13 @@ describe('LineChart', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      props: { plugins: testPlugin }
+      props: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/test/Pie.spec.ts
+++ b/test/Pie.spec.ts
@@ -31,15 +31,13 @@ describe('PieChart', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      props: { plugins: testPlugin }
+      props: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/test/PolarArea.spec.ts
+++ b/test/PolarArea.spec.ts
@@ -32,15 +32,13 @@ describe('PolarChart', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      props: { plugins: testPlugin }
+      props: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/test/Radar.spec.ts
+++ b/test/Radar.spec.ts
@@ -31,15 +31,13 @@ describe('RadarChart', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      props: { plugins: testPlugin }
+      props: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/test/Scatter.spec.ts
+++ b/test/Scatter.spec.ts
@@ -32,15 +32,13 @@ describe('ScatterChart', () => {
 
   it('should add inline plugins based on prop', () => {
     const testPlugin = {
-      title: {
-        display: true
-      }
+      id: 'test'
     }
 
     const wrapper = mount(Component, {
-      props: { plugins: testPlugin }
+      props: { plugins: [testPlugin] }
     })
 
-    expect(Object.keys(wrapper.props().plugins).length).toEqual(1)
+    expect(wrapper.props().plugins.length).toEqual(1)
   })
 })

--- a/test/examples/BarChart.ts
+++ b/test/examples/BarChart.ts
@@ -10,7 +10,7 @@ import {
   BarElement,
   CategoryScale,
   LinearScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale)
@@ -42,8 +42,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'bar'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'bar'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/test/examples/BubbleChart.ts
+++ b/test/examples/BubbleChart.ts
@@ -9,7 +9,7 @@ import {
   Legend,
   PointElement,
   LinearScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, PointElement, LinearScale)
@@ -41,8 +41,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'bubble'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'bubble'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/test/examples/CustomChart.ts
+++ b/test/examples/CustomChart.ts
@@ -11,7 +11,7 @@ import {
   PointElement,
   CategoryScale,
   LinearScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(
@@ -80,8 +80,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'line'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'line'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/test/examples/DoughnutChart.ts
+++ b/test/examples/DoughnutChart.ts
@@ -8,7 +8,7 @@ import {
   Legend,
   ArcElement,
   CategoryScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, ArcElement, CategoryScale)
@@ -40,8 +40,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'doughnut'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'doughnut'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/test/examples/LineChart.ts
+++ b/test/examples/LineChart.ts
@@ -8,7 +8,7 @@ import {
   Legend,
   LineElement,
   LinearScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, LineElement, LinearScale)
@@ -40,8 +40,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'line'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'line'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/test/examples/PieChart.ts
+++ b/test/examples/PieChart.ts
@@ -8,7 +8,7 @@ import {
   Legend,
   ArcElement,
   CategoryScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, ArcElement, CategoryScale)
@@ -40,8 +40,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'pie'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'pie'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/test/examples/PolarAreaChart.ts
+++ b/test/examples/PolarAreaChart.ts
@@ -8,7 +8,7 @@ import {
   Legend,
   ArcElement,
   RadialLinearScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, ArcElement, RadialLinearScale)
@@ -40,8 +40,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'polarArea'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'polarArea'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/test/examples/RadarChart.ts
+++ b/test/examples/RadarChart.ts
@@ -8,7 +8,7 @@ import {
   Legend,
   PointElement,
   RadialLinearScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, PointElement, RadialLinearScale)
@@ -40,8 +40,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'radar'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'radar'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/test/examples/ReactiveChart.ts
+++ b/test/examples/ReactiveChart.ts
@@ -8,7 +8,7 @@ import {
   BarElement,
   CategoryScale,
   LinearScale,
-  PluginOptionsByType,
+  Plugin,
   ChartData
 } from 'chart.js'
 
@@ -41,8 +41,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'bar'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'bar'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/test/examples/ReactivePropChart.ts
+++ b/test/examples/ReactivePropChart.ts
@@ -8,7 +8,7 @@ import {
   BarElement,
   CategoryScale,
   LinearScale,
-  PluginOptionsByType,
+  Plugin,
   ChartData,
   DefaultDataPoint
 } from 'chart.js'
@@ -48,8 +48,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'bar'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'bar'>[]>,
+      default: () => []
     }
   },
   setup(props) {

--- a/test/examples/ScatterChart.ts
+++ b/test/examples/ScatterChart.ts
@@ -8,7 +8,7 @@ import {
   Legend,
   LineElement,
   CategoryScale,
-  PluginOptionsByType
+  Plugin
 } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, LineElement, CategoryScale)
@@ -40,8 +40,8 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'scatter'>>,
-      default: () => {}
+      type: Array as PropType<Plugin<'scatter'>[]>,
+      default: () => []
     }
   },
   setup(props) {


### PR DESCRIPTION
change chart plugins type from object to array, fix tests and examples

### Fix or Enhancement?
fix https://github.com/apertureless/vue-chartjs/issues/782#issue-1183382468


- [x] All tests passed


### Environment
- OS: BigSur MacOs
- NPM Version: 8.5.1

