### PR TITLE
Fix reactive charts update

### DIFF
--- a/website/src/guide/index.md
+++ b/website/src/guide/index.md
@@ -243,6 +243,10 @@ Charts will emit events if the data changes. You can listen to them in the chart
 - `chart:updated` - if the update handler performs an update instead of a re-render
 - `labels:updated` - if new labels were set
 
+### chartjs-plugin-annotation
+
+When using [chartjs-plugin-annotation](https://www.chartjs.org/chartjs-plugin-annotation/latest/) and **Vue 2** simultaneously, you will not be able to place multiple reactive charts on one page.
+
 ## Examples
 
 ### Chart with props


### PR DESCRIPTION

### Fix or Enhancement?
Fix [bug](#801) updating multiple reactive charts on one page, except when using the chartjs-plugin-annotation and Vue 2 simultaneously.

- [x] All tests passed


### Environment
- OS: BigSur MacOs
- NPM Version: 8.5.1

