### PR TITLE
feat(legacy-charts): add typescript definitions for legacy charts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist/*
 node_modules/*
+legacy/index*

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,4 @@ npm-debug.log*
 coverage
 
 # legacy builds
-/legacy/index.cjs
-/legacy/index.cjs.map
-/legacy/index.js
-/legacy/index.js.map
+/legacy/index*

--- a/legacy/package.json
+++ b/legacy/package.json
@@ -5,7 +5,8 @@
     "module": "./legacy/index.js"
   },
   "scripts": {
-    "unit": "jest -c jest.config.json"
+    "unit": "jest -c jest.config.json",
+    "emitDeclarations": "tsc index.js --allowJs  --skipLibCheck --declaration --emitDeclarationOnly --declarationMap"
   },
   "devDependencies": {
     "@babel/core": "7.17.9",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
   "scripts": {
     "prepublishOnly": "pnpm test && pnpm build && del ./package && clean-publish",
     "postpublish": "del ./package",
-    "emitDeclarations": "tsc --emitDeclarationOnly",
+    "emitDeclarations:legacy": "cd legacy && pnpm emitDeclarations",
+    "emitDeclarations:base": "tsc --emitDeclarationOnly",
+    "emitDeclarations": "pnpm emitDeclarations:base && pnpm emitDeclarations:legacy",
     "build": "rollup -c & pnpm emitDeclarations",
     "unit": "pnpm unit:base && pnpm unit:legacy",
     "unit:base": "jest -c jest.config.json",


### PR DESCRIPTION
### Fix or Enhancement?
add typescript definitions for legacy charts
#825


- [x] All tests passed


### Environment
- OS: BigSur MacOs
- NPM Version: 8.5.1

