### PR TITLE
docs: fix typo in guide

### DIFF
--- a/website/src/guide/index.md
+++ b/website/src/guide/index.md
@@ -397,7 +397,7 @@ export default {
 
 ### Chart with API data
 
-A common pattern is to use an API to retrieve your data. However, there are some things to keep in mind. The most common problem is that you mount your chart component directly and pass in data from an asyncronous API call. The problem with this approach is that Chart.js tries to render your chart and access the chart data syncronously, so your chart mounts before the API data arrives.
+A common pattern is to use an API to retrieve your data. However, there are some things to keep in mind. The most common problem is that you mount your chart component directly and pass in data from an asynchronous API call. The problem with this approach is that Chart.js tries to render your chart and access the chart data syncronously, so your chart mounts before the API data arrives.
 
 To prevent this, a simple `v-if` is the best solution.
 


### PR DESCRIPTION
Replace "asyncronous" with the correct spelling "asynchronous"



### Fix or Enhancement?


- [ ] All tests passed


### Environment
- OS: n/a
- NPM Version: n/a

