### PR TITLE
docs: fix Plugin type import

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ or in TypeScript
 // BarChart.ts
 import { defineComponent, h, PropType } from 'vue'
 import { Bar } from 'vue-chartjs'
-import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale, PluginOptionsByType } from 'chart.js'
+import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale, Plugin } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale)
 

--- a/website/src/guide/index.md
+++ b/website/src/guide/index.md
@@ -128,7 +128,7 @@ or in TypeScript:
 ```ts
 import { defineComponent, h, PropType } from 'vue'
 import { Bar } from 'vue-chartjs'
-import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale, PluginOptionsByType } from 'chart.js'
+import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale, Plugin } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale)
 
@@ -157,7 +157,7 @@ export default defineComponent({
       default: () => {}
     },
     plugins: {
-      type: Object as PropType<PluginOptionsByType<'bar'>>,
+      type: Object as PropType<Plugin<'bar'>>,
       default: () => {}
     }
   },


### PR DESCRIPTION
Update `PluginOptionsByType` in doc examples to `Plugin`

Missed spots from https://github.com/apertureless/vue-chartjs/commit/65762c893175b1d24245020e2ff74d3ba633a6fa

### Fix or Enhancement?


- [ ] All tests passed


### Environment
- OS: n/a
- NPM Version: n/a

