### PR TITLE
feat(package): use conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,12 @@
   "publishConfig": {
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
+    "exports": {
+      ".": {
+        "import": "./dist/index.js",
+        "require": "./dist/index.cjs"
+      }
+    },
     "directory": "package"
   },
   "files": [


### PR DESCRIPTION
Adding this makes one able to import `vue-chartjs` in Nuxt 3 without problems. It would otherwise import CJS by default. https://nodejs.org/api/packages.html#conditional-exports

If you're fine with this change, would you add a `hacktoberfest-accepted` label to this PR, please? :)