### PR TITLE
feat: add canvasAttrs prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Just create your own component.
     :chart-id="chartId"
     :dataset-id-key="datasetIdKey"
     :plugins="plugins"
+    :canvas-attrs="canvasAttrs"
     :css-classes="cssClasses"
     :styles="styles"
     :width="width"
@@ -111,6 +112,10 @@ export default {
     height: {
       type: Number,
       default: 400
+    },
+    canvasAttrs: {
+      type: Object,
+      default: () => ({})
     },
     cssClasses: {
       default: '',
@@ -166,6 +171,10 @@ export default defineComponent({
       type: Number,
       default: 400
     },
+    canvasAttrs: {
+      type: Object as PropType<Partial<CanvasHTMLAttributes>>,
+      default: () => ({}),
+    },
     cssClasses: {
       default: '',
       type: String
@@ -194,6 +203,7 @@ export default defineComponent({
         chartId: props.chartId,
         width: props.width,
         height: props.height,
+        canvasAttrs: props.canvasAttrs,
         cssClasses: props.cssClasses,
         styles: props.styles,
         plugins: props.plugins

--- a/src/BaseCharts.ts
+++ b/src/BaseCharts.ts
@@ -28,7 +28,8 @@ import {
   watch,
   isProxy,
   toRaw,
-  PropType
+  PropType,
+  CanvasHTMLAttributes
 } from 'vue'
 
 import {
@@ -85,6 +86,10 @@ export const generateChart = <
       height: {
         type: Number,
         default: 400
+      },
+      canvasAttrs: {
+        type: Object as PropType<Partial<CanvasHTMLAttributes>>,
+        default: () => ({}),
       },
       cssClasses: {
         type: String,
@@ -266,6 +271,7 @@ export const generateChart = <
             id: props.chartId,
             width: props.width,
             height: props.height,
+            ...props.canvasAttrs,
             ref: canvasEl
           })
         ])

--- a/website/src/api/index.md
+++ b/website/src/api/index.md
@@ -12,6 +12,7 @@ There are some basic props defined in the components provided by `vue-chartjs`.
 | chartId | Id of the canvas |
 | width | Chart width |
 | height | Chart height |
+| canvasAttrs | Attributes of the canvas |
 | cssClasses | String with css classes for the surrounding div |
 | styles | Object with css styles for the surrounding div container |
 | plugins | Array with Chart plugins |

--- a/website/src/ja/api/index.md
+++ b/website/src/ja/api/index.md
@@ -9,6 +9,7 @@
 | width | チャート幅 |
 | height | チャート高さ |
 | chart-id | canvas要素のid |
+| canvasAttrs | canvas要素の属性 |
 | css-classes | 囲んでいる div の css クラス (文字列) |
 | styles | 囲んでいる div の css クラス (オブジェクト) |
 | plugins | chartjs プラグイン (配列) |

--- a/website/src/pt-br/api/index.md
+++ b/website/src/pt-br/api/index.md
@@ -4,14 +4,15 @@
 
 Existem alguns props básicas definidas nos componentes fornecidos pelo `vue-chartjs`. Porque você os `estende`, eles são _invisíveis_, mas você pode substituí-los:
 
-| Prop        | Descrição                                               |
-| ----------- | ------------------------------------------------------- |
-| width       | largura do gráfico                                      |
-| height      | altura do gráfico                                       |
-| chart-id    | Id da tela                                              |
-| css-classes | String com classes css para a div circundante           |
-| styles      | Objeto com estilos css para o div contêiner circundante |
-| plugins     | Array com plugins chartjs                               |
+| Prop         | Descrição                                               |
+| ------------ | ------------------------------------------------------- |
+| width        | largura do gráfico                                      |
+| height       | altura do gráfico                                       |
+| chart-id     | Id da tela                                              |
+| canvas-attrs | Atributos da tela                                       |
+| css-classes  | String com classes css para a div circundante           |
+| styles       | Objeto com estilos css para o div contêiner circundante |
+| plugins      | Array com plugins chartjs                               |
 
 ## Eventos
 

--- a/website/src/ru/api/index.md
+++ b/website/src/ru/api/index.md
@@ -9,6 +9,7 @@
 | width | ширина графика |
 | height | высота графика |
 | chart-id | id canvas-элемента |
+| canvas-attrs | атрибуты canvas-элемента |
 | css-classes | String с классами CSS для родительского элемента div |
 | styles | Object со стилями CSS для родительского элемента div |
 | plugins | Array с плагинами chartjs |

--- a/website/src/zh-cn/api/index.md
+++ b/website/src/zh-cn/api/index.md
@@ -9,6 +9,7 @@
 | width | 图表宽度 |
 | height | 图表高度 |
 | chart-id | canvas的id |
+| canvasAttrs | canvas的属性 |
 | css-classes |  css类的字符串 |
 | styles |  css 样式对象 |
 | plugins | chartjs 插件数组 |


### PR DESCRIPTION

### Enhancement

This pull request adds a `canvasAttrs` property which allows users to customize the attributes (e.g., `aria-label`) to be present on the canvas element that draws the chart.


- [x] All tests passed



