### PR TITLE
fix:  missing main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Vue.js wrapper for chart.js for creating beautiful charts.",
   "author": "Jakub Juszczak <jakub@posteo.de>",
   "homepage": "http://vue-chartjs.org",
+  "main": "dist/index.js",
   "license": "MIT",
   "contributors": [
     {


### PR DESCRIPTION
Because there is no `main` defined in `package.json`, any file that imports `vue-chartjs` in a project that use `eslint-plugin-import` will get below eslint error

![Screenshot 2022-12-16 at 5 12 58 PM](https://user-images.githubusercontent.com/31390562/208197577-ebf527a6-459e-448b-aafe-c444652c6803.png)
