### PR TITLE
chore: remove links to Cube's Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Supports Chart.js v4.
 <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
 <a href="#docs">Docs</a>
 <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-<a href="https://slack.cube.dev/?ref=eco-vue-chartjs">Slack</a>
-<span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
 <a href="https://stackoverflow.com/questions/tagged/vue-chartjs">Stack Overflow</a>
 <br />
 <hr />

--- a/website/src/.vitepress/config.ts
+++ b/website/src/.vitepress/config.ts
@@ -35,10 +35,6 @@ export default defineConfig({
         activeMatch: '^/examples/'
       },
       {
-        text: 'Slack',
-        link: 'https://slack.cube.dev/?ref=eco-vue-chartjs'
-      },
-      {
         text: 'Stack Overflow',
         link: 'https://stackoverflow.com/questions/tagged/vue-chartjs/'
       }


### PR DESCRIPTION
I've seen a number of instances when folks get lost in that Slack community and don't always get advice on using the library there. So, let's remove the links to remove confusion.