### PR TITLE
Add destroyDelay prop

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -3,7 +3,7 @@ import {
   defineComponent,
   h,
   nextTick,
-  onBeforeUnmount,
+  onUnmounted,
   onMounted,
   ref,
   shallowRef,
@@ -60,7 +60,7 @@ export const Chart = defineComponent({
 
     onMounted(renderChart)
 
-    onBeforeUnmount(destroyChart)
+    onUnmounted(destroyChart)
 
     watch(
       [() => props.options, () => props.data],

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -49,8 +49,15 @@ export const Chart = defineComponent({
       const chart = toRaw(chartRef.value)
 
       if (chart) {
-        chart.destroy()
-        chartRef.value = null
+        if (props.destroyDelay > 0) {
+          setTimeout(() => {
+            chart.destroy()
+            chartRef.value = null
+          }, props.destroyDelay)
+        } else {
+          chart.destroy()
+          chartRef.value = null
+        }
       }
     }
 

--- a/src/props.ts
+++ b/src/props.ts
@@ -44,6 +44,10 @@ export const Props = {
     type: String as PropType<ChartType>,
     required: true
   },
+  destroyDelay: {
+    type: Number,
+    default: 0 // No delay by default
+  },
   ...CommonProps,
   ...A11yProps
 } as const


### PR DESCRIPTION
Fixes https://github.com/apertureless/vue-chartjs/issues/579

The original issue was marked as completed, but it was not fixed. To address this issue, I've added a new prop that delays calling `destroy` on unMount. No matter how long your transition is, you can adjust the charts as a result

## Before
https://github.com/apertureless/vue-chartjs/assets/4270980/e79527aa-9b3f-44a0-9e09-44bff5411a9d 

## With delay
https://github.com/apertureless/vue-chartjs/assets/4270980/c469443e-b656-46e3-89c3-17e151dcb85e

