### PR TITLE
fix(types): bar chart data

### DIFF
--- a/src/typedCharts.ts
+++ b/src/typedCharts.ts
@@ -11,12 +11,11 @@ import {
   RadarController,
   ScatterController
 } from 'chart.js'
-
+import type { DistributiveArray } from 'chart.js/dist/types/utils'
 import type { TypedChartComponent, ChartComponentRef } from './types.js'
 import { CommonProps } from './props.js'
 import { Chart } from './chart.js'
 import { compatProps } from './utils.js'
-import type { DistributiveArray } from 'chart.js/dist/types/utils'
 
 export function createTypedChart<
   TType extends ChartType = ChartType,

--- a/src/typedCharts.ts
+++ b/src/typedCharts.ts
@@ -11,10 +11,12 @@ import {
   RadarController,
   ScatterController
 } from 'chart.js'
+
 import type { TypedChartComponent, ChartComponentRef } from './types.js'
 import { CommonProps } from './props.js'
 import { Chart } from './chart.js'
 import { compatProps } from './utils.js'
+import type { DistributiveArray } from 'chart.js/dist/types/utils'
 
 export function createTypedChart<
   TType extends ChartType = ChartType,
@@ -54,7 +56,14 @@ export function createTypedChart<
   }) as any
 }
 
-export const Bar = /* #__PURE__ */ createTypedChart('bar', BarController)
+interface ExtendedDataPoint {
+  [key: string]: string | number | null | ExtendedDataPoint
+}
+
+export const Bar = /* #__PURE__ */ createTypedChart<
+  'bar',
+  DefaultDataPoint<'bar'> | DistributiveArray<ExtendedDataPoint>
+>('bar', BarController)
 
 export const Doughnut = /* #__PURE__ */ createTypedChart(
   'doughnut',


### PR DESCRIPTION
## Related issue

https://github.com/apertureless/vue-chartjs/issues/1058

## Motivation of change

As you can see in the original issue, there is a problem with Bar chart typing (other charts maybe also have it). The **Data** type is not fully correct since `Bar` chart can accept other data types apart from the described ones in the `typedCharts.d.ts`.

### Previously

<img width="1090" alt="image" src="https://github.com/apertureless/vue-chartjs/assets/36737084/7a49769e-7760-483a-99d1-09107dbbe73d">

### Now

<img width="1043" alt="image" src="https://github.com/apertureless/vue-chartjs/assets/36737084/eb6c06c2-a599-4298-8e73-453ba844ec3c">

## Notes about `ExtendedDataPoint`

There's a new type named `ExtendedDataPoint` which represents objects like `{ x: 1, y: 2 }`, `{ id: 'Sales', nested: {value: 1500}` and so on. Based on https://www.chartjs.org/docs/latest/general/data-structures.html