### PR TITLE
Update typedCharts.ts

### DIFF
--- a/src/typedCharts.ts
+++ b/src/typedCharts.ts
@@ -55,7 +55,7 @@ export function createTypedChart<
   }) as any
 }
 
-interface ExtendedDataPoint {
+export interface ExtendedDataPoint {
   [key: string]: string | number | null | ExtendedDataPoint
 }
 


### PR DESCRIPTION
Export `ExtendedDataPoint` to prevent build error when a local project exports type of `Bar`

```
test (20.x): library/api/component.chart/bar-chart/bar-chart.vue#L47
Default export of the module has or is using private name 'ExtendedDataPoint'.
```